### PR TITLE
Sending notifications

### DIFF
--- a/MMM-mqtt.js
+++ b/MMM-mqtt.js
@@ -83,6 +83,7 @@ Module.register('MMM-mqtt', {
     }
 
     this.sendSocketNotification("MQTT_SEND", {
+      mqttServer: self.config.mqttServer,
       topic: topic,
       payload: payload
     });

--- a/MMM-mqtt.js
+++ b/MMM-mqtt.js
@@ -12,6 +12,7 @@ Module.register('MMM-mqtt', {
 
   defaults: {
     mqttServer: 'mqtt://test.mosquitto.org',
+    mode: 'receive',
     loadingText: 'Loading MQTT Data...',
     topic: '',
     showTitle: false,
@@ -28,7 +29,7 @@ Module.register('MMM-mqtt', {
   },
 
   updateMqtt: function(self) {
-    self.sendSocketNotification('MQTT_SERVER', { mqttServer: self.config.mqttServer, topic: self.config.topic });
+    self.sendSocketNotification('MQTT_SERVER', { mqttServer: self.config.mqttServer, topic: self.config.topic, mode: self.config.mode });
     setTimeout(self.updateMqtt, self.config.interval, self);
   },
 
@@ -63,6 +64,28 @@ Module.register('MMM-mqtt', {
     if (notification === 'ERROR') {
       this.sendNotification('SHOW_ALERT', payload);
     }
+  },
+
+  notificationReceived: function(notification, payload, sender) {
+    var self = this;
+
+    if (self.config.mode !== "send") {
+      return;
+    }
+
+    var topic;
+    if (sender) {
+      Log.log(this.name + " received a module notification: " + notification + " from sender: " + sender.name + ": ", payload);
+      topic = this.config.topic + "/" + sender.name + "/" + notification;
+    } else {
+      Log.log(this.name + " received a system notification: " + notification + ": ", payload);
+      topic = this.config.topic + "/" + notification;
+    }
+
+    this.sendSocketNotification("MQTT_SEND", {
+      topic: topic,
+      payload: payload
+    });
   }
 
 });

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The following options can be configured:
 
 | Option  | Description  |
 |---|---|
-| `mqttServer`  | Connection string for the server to connect to (`mqtt://localhost`)  |
+| `mqttServer`  | Connection string for the server to connect to (e.g. `mqtt://localhost`) **See:** Server URL  |
 | `loadingText`  | Text to display while waiting for data to load  |
 | `topic`  | MQTT Topic to subscribe to on the server (`sensors/temperature/livingroom`)  |
 | `showTitle`  | Boolean to show/hide a title (default: `false`)  |
@@ -37,8 +37,17 @@ The following options can be configured:
 | `interval`  | Refresh interval, not including MQTT subscription deliveries. (default: `300000`)  |
 | `postText`  | Text to append after the data received from MQTT (default: `''`)  |
 
-## Known Limitations
-- Currently only supports unencrypted/unauthenticated MQTT connections.  
+## Server URL
+The server URL can be configured with all options supported by [URL.parse](https://nodejs.org/api/url.html#url_url_strings_and_url_objects). The format used is
+
+```
+   mqtt:    //    user   :   pass   @ some.host.com : 1883
+| protocol |  | username | password |   hostname    | port |
+```
+
+Supported protocols include:
+- mqtt
+- mqtts
 
 ## Dependencies
 - [mqtt](https://www.npmjs.com/package/mqtt) (installed via `npm install`)
@@ -49,7 +58,7 @@ Contributions of all kinds are welcome, not only in the form of code but also wi
 
 Please keep the following in mind:
 
-- **Bug Reports**:  Make sure you're running the latest version. If the issue(s) still persist: please open a clearly documented issue with a clear title. 
+- **Bug Reports**:  Make sure you're running the latest version. If the issue(s) still persist: please open a clearly documented issue with a clear title.
 - **Minor Bug Fixes**: Please send a pull request with a clear explanation of the issue or a link to the issue it solves.
 - **Major Bug Fixes**: please discuss your approach in an GitHub issue before you start to alter a big part of the code.
 - **New Features**: please please discuss in a GitHub issue before you start to alter a big part of the code. Without discussion upfront, the pull request will not be accepted / merged.

--- a/node_helper.js
+++ b/node_helper.js
@@ -13,53 +13,57 @@ var mqtt = require('mqtt');
 module.exports = NodeHelper.create({
   start: function() {
     console.log('MMM-mqtt started ...');
+    this.clients = [];
   },
 
-  getMqtt: function(config) {
+  connectMqtt: function(config) {
     var self = this;
-    var client = mqtt.connect(config.mqttServer);
-    self.client = client;
+    var client;
 
-    console.log("Creating new MQTT client: ", config);
+    if(typeof self.clients[config.mqttServer] === "undefined") {
+      console.log("Creating new MQTT client for url: ", config.mqttServer);
+      client = mqtt.connect(config.mqttServer);
+      self.clients[config.mqttServer] = client;
 
-    client.on('connect', function() {
-      client.subscribe(config.topic);
-    });
-
-    client.on('error', function(error) {
-      console.log('*** MQTT JS ERROR ***: ' + error);
-      self.sendSocketNotification('ERROR', {
-        type: 'notification',
-        title: 'MQTT Error',
-        message: 'The MQTT Client has suffered an error: ' + error
+      client.on('error', function(error) {
+        console.log('*** MQTT JS ERROR ***: ' + error);
+        self.sendSocketNotification('ERROR', {
+          type: 'notification',
+          title: 'MQTT Error',
+          message: 'The MQTT Client has suffered an error: ' + error
+        });
       });
-    });
 
-    client.on('offline', function() {
-      console.log('*** MQTT Client Offline ***');
-      self.sendSocketNotification('ERROR', {
-        type: 'notification',
-        title: 'MQTT Offline',
-        message: 'MQTT Server is offline.'
+      client.on('offline', function() {
+        console.log('*** MQTT Client Offline ***');
+        self.sendSocketNotification('ERROR', {
+          type: 'notification',
+          title: 'MQTT Offline',
+          message: 'MQTT Server is offline.'
+        });
+        client.end();
       });
-      client.end();
-    });
+    } else {
+      client = self.clients[config.mqttServer];
+    }
 
     if(config.mode !== 'send') {
+      client.subscribe(config.topic);
+
       client.on('message', function(topic, message) {
         self.sendSocketNotification('MQTT_DATA', {'topic':topic, 'data':message.toString()});
-        // client.end();
       });
     }
   },
 
   socketNotificationReceived: function(notification, payload) {
-    var self = this;
-
     if (notification === 'MQTT_SERVER') {
-      this.getMqtt(payload);
+      this.connectMqtt(payload);
     } else if(notification == 'MQTT_SEND') {
-      self.client.publish(payload.topic, JSON.stringify(payload.payload));
+      var client = this.clients[payload.mqttServer];
+      if(typeof client !== "undefined") {
+        client.publish(payload.topic, JSON.stringify(payload.payload));
+      }
     }
   }
 });

--- a/node_helper.js
+++ b/node_helper.js
@@ -15,12 +15,12 @@ module.exports = NodeHelper.create({
     console.log('MMM-mqtt started ...');
   },
 
-  getMqtt: function(payload) {
+  getMqtt: function(config) {
     var self = this;
-    var client = mqtt.connect(payload.mqttServer);
+    var client = mqtt.connect(config.mqttServer);
 
     client.on('connect', function() {
-      client.subscribe(payload.topic);
+      client.subscribe(config.topic);
     });
 
     client.on('error', function(error) {


### PR DESCRIPTION
This PR adds the possibility to have MMM-mqtt send the notifications from all modules to an MQTT server. Enabling en ecosystem to respond to changes happening on the MagicMirror. This would for example integrate extremely well with a motion sensor.

Additionally it makes the module reuse server connections for multiple modules if the server URL is the same. 